### PR TITLE
Accepting value Json in parameter of request's body in custom Scalar (Fixing test)

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -780,7 +780,7 @@ func validateValueType(c *opContext, v types.Value, t types.Type) (bool, string)
 				return true, ""
 			}
 
-			return false, ""
+			return false, fmt.Sprintf("Expected type %q, found %s.", t, v)
 		}
 		
 		return true, ""


### PR DESCRIPTION
Hi,

### Description
This RP goal is to allow you to accept Json (Map) in the request body without having to separate the json value for variables, as mentioned in this comment #350 (comment)

### Example usage
Data is a type custom Scalar Map

mutation {
    hello (
        name: "Name",
        data: { 
            param1: "Test 1",
            param2: "Test 2"
        }
    )
}